### PR TITLE
Add new project to bleep.publish.yaml

### DIFF
--- a/bleep.publish.yaml
+++ b/bleep.publish.yaml
@@ -1,6 +1,7 @@
 groupId: io.github.nafg.bleep-plugins
 projects:
   - bleep-plugin-publish
+  - bleep-plugin-openapi-codegen-zio-http
 sonatype:
   profileName: io.github.nafg
   bundleName: bleep-plugins


### PR DESCRIPTION
Include bleep-plugin-openapi-codegen-zio-http in the projects list. This update is required to ensure the new plugin is recognized and processed during publication.
