### PR TITLE
chore: update .gitignore to exclude IDE and build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ hs_err_pid*
 
 /.bleep/
 /.bsp/
+
+/.idea/libraries
+/.idea/modules
+
+.metals/
+
+.aider*


### PR DESCRIPTION
Added entries to .gitignore to exclude IDE-specific files from .idea/
(libraries and modules), the .metals/ directory used by Scala Metals, and
.aider* files. This helps keep the repository clean from environment-specific
and build-related files that should not be committed.
